### PR TITLE
Check status of file before downloading

### DIFF
--- a/iCloudDownlader/Downloader.swift
+++ b/iCloudDownlader/Downloader.swift
@@ -15,16 +15,32 @@ class Downloader {
     let consoleIO = ConsoleIO()
     
     func fetchFile(fileUrl : URL) {
-        if fm.isUbiquitousItem(at: fileUrl){
-            do {
-                try fm.startDownloadingUbiquitousItem(at: fileUrl)
-                consoleIO.writeMessage("Info : \(fileUrl.lastPathComponent) is downloading")
-            } catch  {
-                consoleIO.writeMessage("Can't download \(fm.displayName(atPath: fileUrl.lastPathComponent))", to: .error)
-            }
+        let status: URLResourceValues;
+        
+        do {
+            status = try fileUrl.resourceValues(forKeys: [.isUbiquitousItemKey,
+                                                          .ubiquitousItemIsDownloadingKey,
+                                                          .ubiquitousItemDownloadingStatusKey]);
+        } catch {
+            consoleIO.writeMessage("Can't get attributes for file \(fm.displayName(atPath: fileUrl.lastPathComponent)): \(error)", to: .error)
+            return
         }
-        else {
-            consoleIO.writeMessage("\(fm.displayName(atPath: fileUrl.lastPathComponent)) is already download", to: .warning)
+
+        if status.isUbiquitousItem ?? false {
+            if status.ubiquitousItemDownloadingStatus == .current {
+                consoleIO.writeMessage("\(fm.displayName(atPath: fileUrl.lastPathComponent)) is already downloaded", to: .warning)
+            } else if status.ubiquitousItemIsDownloading ?? false {
+                consoleIO.writeMessage("\(fm.displayName(atPath: fileUrl.lastPathComponent)) is downloading")
+            } else {
+                do {
+                    try fm.startDownloadingUbiquitousItem(at: fileUrl)
+                    consoleIO.writeMessage("Info: \(fileUrl.lastPathComponent) is downloading")
+                } catch {
+                    consoleIO.writeMessage("Can't download \(fm.displayName(atPath: fileUrl.lastPathComponent)): \(error)", to: .error)
+                }
+            }
+        } else {
+            consoleIO.writeMessage("\(fm.displayName(atPath: fileUrl.lastPathComponent)) is not an iCloud file", to: .warning)
         }
     }
     


### PR DESCRIPTION
This adds code to retrieve more metadata about the ubiquitous item, in particular whether the file is downloaded, and whether the file is currently downloading.

The result is that there's more specific output for other file statuses, and the download will only be requested if the file is either out of date or missing.

I believe this requires macOS 10.12, up from the 10.11 listed in the Readme, however, [the current MACOS_DEPLOYMENT_TARGET is already 10.13](https://github.com/ticky/iCloudDownloader/blob/61d7b3e9ab464da7b3589b60c92453f83f657156/iCloudDownlader.xcodeproj/project.pbxproj#L246), so I suspect this didn't work as expected on 10.11 before anyway!

Additionally, this was written with Xcode 11.3 and Swift 5 migration enabled, so I'm not clear on whether any of this syntax is backwards-incompatible.

Thank you for this handy little tool! 💜